### PR TITLE
start with remote backend

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,74 +1,61 @@
-var express = require('express');
-var Promise = require('bluebird');
-
-var itemsapi = require('itemsapi');
-
-var ELASTICSEARCH_URL = '127.0.0.1:9200';
-// heroku elasticsearch addon
-if (process.env.SEARCHBOX_URL) {
-  ELASTICSEARCH_URL = process.env.SEARCHBOX_URL;
-}
-
-var PORT = process.env.PORT;
-console.log(PORT);
-console.log(ELASTICSEARCH_URL);
-//console.log(__dirname);
-
-
-
-itemsapi.init({
-  server: {
-    port: PORT,
-    host: "0.0.0.0",
-    logger: false
-  },
-  elasticsearch: {
-    host: ELASTICSEARCH_URL
-  },
-  collections: {
-    db: 'json',
-    filename:  'collections.json'
-  }
-})
-
-var app = itemsapi.get('express');
+var express = require('express')
+var ItemsAPI = require('itemsapi-node');
+// PORT should go to the config because it is repeated many times
+var PORT = process.env.PORT || 3000;
 var path = require('path')
 var _ = require('lodash')
 var ui = require('./src/helpers/ui')
+var bodyParser = require('body-parser');
+
+
+var BACKEND_URL = process.env.BACKEND_URL;
+
+var app
+if (BACKEND_URL) {
+  app = require('./itemsapi-remote-proxy-server')
+} else {
+  var itemsapiServer = require('./itemsapi-local-server')
+  app = itemsapiServer.get('express');
+}
 
 app.use('/app', express.static('app'));
-
-var bodyParser = require('body-parser');
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-
-var ItemsAPI = require('itemsapi-node');
-
+/**
+ * run ItemsAPI client for further use
+ */
 app.all('*', function(req, res, next) {
   var client = new ItemsAPI('http://localhost:' + PORT + '/api/v1');
   req.client = client;
   next();
 })
 
+/**
+ * main angular page
+ */
 app.get('/', function(req, res) {
   res.redirect('/app');
   //return res.sendFile(path.join(__dirname+ '/app/index.html'));
 });
 
+/**
+ * add data out of the box with angular form
+ */
 app.post('/add-data', function(req, res) {
   if (req.body.data) {
     req.body.data = JSON.parse(req.body.data)
   }
 
-  //console.log(req.body);
-  //console.log(_.keys(req.body.data))
   return req.client.createProject(req.body)
   .then(function(result) {
     res.json(result);
   })
 });
 
+/**
+ * check metadata to generate table
+ */
 app.get('/metadata', function(req, res) {
   req.client.setName(req.query.name)
   return req.client.search({
@@ -80,9 +67,3 @@ app.get('/metadata', function(req, res) {
   })
 });
 
-
-itemsapi.start(function serverStart(serverInstance) {
-  var host = serverInstance.address().address;
-  var port = serverInstance.address().port;
-  itemsapi.get('logger').info('ItemsAPI started on http://%s:%s', host, port)
-});

--- a/itemsapi-local-server.js
+++ b/itemsapi-local-server.js
@@ -1,0 +1,34 @@
+var express = require('express');
+var Promise = require('bluebird');
+var itemsapi = require('itemsapi');
+
+var ELASTICSEARCH_URL = '127.0.0.1:9200';
+// heroku elasticsearch addon
+if (process.env.SEARCHBOX_URL) {
+  ELASTICSEARCH_URL = process.env.SEARCHBOX_URL;
+}
+
+var PORT = process.env.PORT || 3000;
+
+itemsapi.init({
+  server: {
+    port: PORT,
+    host: "0.0.0.0",
+    logger: false
+  },
+  elasticsearch: {
+    host: ELASTICSEARCH_URL
+  },
+  collections: {
+    db: 'json',
+    filename:  'collections.json'
+  }
+})
+
+itemsapi.start(function serverStart(serverInstance) {
+  var host = serverInstance.address().address;
+  var port = serverInstance.address().port;
+  itemsapi.get('logger').info('ItemsAPI started on http://%s:%s', host, port)
+});
+
+module.exports = itemsapi

--- a/itemsapi-remote-proxy-server.js
+++ b/itemsapi-remote-proxy-server.js
@@ -1,0 +1,22 @@
+var express = require('express');
+var app = express();
+
+var proxy = require('express-http-proxy');
+// should come from one config
+var PORT = process.env.PORT || 3000;
+
+// i.e. http://cloud.itemsapi.com/api/v1
+var BACKEND_URL = process.env.BACKEND_URL;
+
+app.listen(PORT, function () {
+  console.log('Proxy server has started on port: ' + PORT);
+});
+
+// proxy server for external backend
+app.use('/api/v1', proxy(BACKEND_URL, {
+  forwardPath: function(req, res) {
+    return req.originalUrl
+  }
+}));
+
+module.exports = app

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "body-parser": "^1.15.2",
     "bower": "^1.7.9",
     "express": "^4.14.0",
+    "express-http-proxy": "^0.10.0",
     "itemsapi": "^1.0.34",
     "itemsapi-node": "^1.0.14",
     "lodash": "^4.13.1",


### PR DESCRIPTION
Makes possible to start dashboard with remote backend (i.e. with demo backend)

Example:
BACKEND_URL=http://cloud.itemsapi.com PORT=3000 npm start
(http://cloud.itemsapi.com is read only)